### PR TITLE
fix broken image URL in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,4 @@
 Repository for the Packt Publishing book
 ## C# 7 and .NET Core: Modern Cross-Platform Development, Second Edition
 
-![C# 7 and .NET Core by Packt Publishing](https://www.packtpub.com/sites/default/files/B06126_0.png)
+![C# 7 and .NET Core by Packt Publishing](https://content.packt.com/B06126/cover_image.jpg)


### PR DESCRIPTION
Hi Mark, thanks for all your hard work writing your books and maintaining these repositories!

This PR fixes the broken image in the main readme. This fix still references an image on the publisher's URL so it is possible it may break again in the future, so let me know if you wish me to instead place a copy of the cover image in this repository and update the readme to reference that file instead.